### PR TITLE
Fix issue with json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## peepdf 3.0.0, 2024-01-02
+## peepdf 3.0.1, 2024-01-04
+
+
+	* Fixes:
+
+		- Fixed an issue where the json output wasn't formulated properly based on the differences in CRLF and blanks in the "IDs" field
+
+
+
+## peepdf 3.0.0, 2024-01-04
 
 
 	* Fixes:

--- a/peepdf/PDFConsole.py
+++ b/peepdf/PDFConsole.py
@@ -2909,7 +2909,7 @@ class PDFConsole(cmd.Cmd):
         else:
             beforeStaticLabel = ""
         if len(args) == 0:
-            statsDict = self.pdfFile.getStats()        
+            statsDict = self.pdfFile.getStats()
             jsonReport = getPeepJSON(statsDict, VERSION)
         elif len(args) > 0:
             message = '[!] Error: The "json" command does not require any arguments'
@@ -2918,13 +2918,13 @@ class PDFConsole(cmd.Cmd):
         else:
             message = '[!] Error: The "json" command failed.'
             self.log_output("json " + argv, message)
-            return False        
+            return False
         self.log_output("json " + argv, jsonReport)
-        
+
     def help_json(self):
         print(f"{newLine}Usage: json")
         print(f"Shows the info for the currently loaded file in JSON format")
-    
+
     def do_log(self, argv):
         args = self.parseArgs(argv)
         if args is None:
@@ -3248,7 +3248,7 @@ class PDFConsole(cmd.Cmd):
             else:
                 message = f'[!] Version {version} does not exist.'
                 self.log_output("objects " + argv, message)
-                return False            
+                return False
         else:
             message = '[!] Error: The "objects" command requires 0 or 1 argument'
             self.log_output("objects " + argv, message)
@@ -4491,7 +4491,7 @@ class PDFConsole(cmd.Cmd):
         else:
             beforeStaticLabel = ""
         if len(args) == 0:
-            statsDict = self.pdfFile.getStats()        
+            statsDict = self.pdfFile.getStats()
             xmlReport = getPeepXML(statsDict, VERSION)
             xmlReport = xmlReport.decode('latin-1')
         elif len(args) >0:
@@ -4503,11 +4503,11 @@ class PDFConsole(cmd.Cmd):
             self.log_output("xml " + argv, message)
             return False
         self.log_output("xml " + argv, xmlReport)
-        
+
     def help_xml(self):
         print(f"{newLine}Usage: xml")
         print(f"Shows the info for the currently loaded file in XML format")
-        
+
     def do_xor(self, argv):
         content = ""
         found = False

--- a/peepdf/PDFUtils.py
+++ b/peepdf/PDFUtils.py
@@ -662,7 +662,7 @@ def getPeepJSON(statsDict, VERSION):
     basicDict["sha1"] = statsDict["SHA1"]
     basicDict["sha256"] = statsDict["SHA256"]
     basicDict["size"] = int(statsDict["Size"])
-    if statsDict["IDs"] != "\r\n":
+    if statsDict["IDs"] not in ("\r\n","\n",None):
         basicDict["ids"] = {}
         ids = statsDict["IDs"].split("\r\n\t")
         for each_id in ids:

--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -256,8 +256,8 @@ def main():
                 try:
                     from peepdf.PDFConsole import PDFConsole
                 except ModuleNotFoundError:
-                    from PDFConsole import PDFConsole                
-                console = PDFConsole(pdf, VT_KEY, args.avoidColors)                
+                    from PDFConsole import PDFConsole
+                console = PDFConsole(pdf, VT_KEY, args.avoidColors)
                 try:
                     console.cmdloop()
                 except:
@@ -265,7 +265,7 @@ def main():
                         "[!] Error: Exception while launching Interactive mode without a PDF file"
                     )
                     traceback.print_exc(file=open(errorsFile, "a"))
-                    raise Exception("PeepException", "Open an Issue on GitHub")               
+                    raise Exception("PeepException", "Open an Issue on GitHub")
             elif (numArgs > 4 and not fileName) or (numArgs == 0 and not args.isInteractive):
                 sys.exit(argsParser.print_help())
             if args.jsonOutput and args.xmlOutput:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ exclude = ["archive*"]
 
 [project]
 name = "peepdf-3"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
   "requests",
   "pypdf",


### PR DESCRIPTION
## peepdf 3.0.1, 2024-01-04


    * Fixes:

        - Fixed an issue where the json output wasn't formulated properly based on the differences in CRLF and blanks in the "IDs" field
