### PR TITLE
Fix TypeError when using "-s SCRIPTFILE"

### DIFF
--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -320,7 +320,7 @@ def main():
                         COLORIZED_OUTPUT = False
                 if args.scriptFile is not None:
                     if os.path.exists(args.scriptFile):
-                        scriptFileObject = open(args.scriptFile, "rb")
+                        scriptFileObject = open(args.scriptFile, "r")
                     else:
                         sys.exit(
                             f"[*] Warning: The file {args.scriptFile} cannot be found - check your path and try again!"


### PR DESCRIPTION
When using the -s SCRIPTFILE argument, the following traceback is generated:

```
Traceback (most recent call last):
File "/opt/tools/virtual_envs/peepdf-3/lib/python3.10/site-packages/peepdf/peepdf.py", line 332, in main
console.cmdloop()
File "/usr/lib/python3.10/cmd.py", line 136, in cmdloop
line = line.rstrip('\r\n')
TypeError: a bytes-like object is required, not 'str'
```

It is likely a remnant of the old python.2 version peepdf