### PR TITLE
Add __main__.py for command line module implementation

### DIFF
--- a/peepdf/__main__.py
+++ b/peepdf/__main__.py
@@ -1,0 +1,4 @@
+from peepdf.peepdf import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
To address #24 , this adds a `__main__.py` file to allow the package to be called as a module at the CLI.