### PR TITLE
Update pyproject to include STPyV8, change py ver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,9 @@ dependencies = [
   "pythonaes",
   "lxml",
   "prettytable>=3.9.0",
+  "STPyV8",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 authors = [
   {name = "Corey Forman (digitalsleuth)", email = "github@digitalsleuth.ca"},
   {name = "Jose Miguel Esparza"}


### PR DESCRIPTION
This PR includes STPyV8 now by default on installation as, since version 12.0.267.16, it is now pip-installable with support for macOS, Linux, and Windows, on python 3.9+.

This PR also changes the default required python to >=3.9 to reflect this change.