### PR TITLE
Add LXML as an optional dependency as opposed to required

### DIFF
--- a/peepdf/PDFUtils.py
+++ b/peepdf/PDFUtils.py
@@ -31,13 +31,18 @@ import json
 from pathlib import Path
 from datetime import datetime as dt
 import requests
-from lxml import etree
 
 
 try:
     from peepdf.PDFVulns import vulnsDict, vulnsVersion
 except ModuleNotFoundError:
     from PDFVulns import vulnsDict, vulnsVersion
+
+try:
+    from lxml import etree
+    LXML_MODULE = True
+except ModuleNotFoundError:
+    LXML_MODULE = False
 
 DTFMT = "%Y%m%d-%H%M%S"
 

--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -35,14 +35,14 @@ from operator import attrgetter
 
 try:
     from peepdf.PDFCore import PDFParser, VERSION
-    from peepdf.PDFUtils import vtcheck, getPeepJSON, getPeepXML, getUpdate, DTFMT
+    from peepdf.PDFUtils import vtcheck, getPeepJSON, getPeepXML, getUpdate, DTFMT, LXML_MODULE
     from peepdf.PDFVulns import vulnsDict
     from peepdf.PDFConsole import PDFConsole, EMU_MODULE
     from peepdf.JSAnalysis import JS_MODULE
     from peepdf.PDFFilters import PIL_MODULE
 except ModuleNotFoundError:
     from PDFCore import PDFParser, VERSION
-    from PDFUtils import vtcheck, getPeepJSON, getPeepXML, getUpdate, DTFMT
+    from PDFUtils import vtcheck, getPeepJSON, getPeepXML, getUpdate, DTFMT, LXML_MODULE
     from PDFVulns import vulnsDict
     from PDFConsole import PDFConsole, EMU_MODULE, DTFMT
     from JSAnalysis import JS_MODULE
@@ -298,6 +298,15 @@ def main():
                 statsDict = pdf.getStats()
 
             if args.xmlOutput:
+                if not LXML_MODULE:
+                    errorMessage = "[!] Error: The lxml module is not installed and is required for XML output."
+                    print(
+                        f"{errorColor}{errorMessage}{resetColor}{newLine}"
+                    )
+                    with open(
+                        errorsFile, "a", encoding="utf-8"
+                    ) as errorLog:
+                        traceback.print_exc(file=errorLog)
                 try:
                     xml = getPeepXML(statsDict, VERSION)
                     xml = xml.decode("latin-1")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
   "colorama",
   "Pillow",
   "pythonaes",
-  "lxml",
   "prettytable>=3.9.0",
   "STPyV8",
 ]
@@ -33,8 +32,12 @@ license = {file = "COPYING"}
 keywords = ["pdf", "peepdf", "forensics"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
-  "Programming Language :: Python :: 3"
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
 ]
+
+[project.optional-dependencies]
+lxml = ["lxml"]
 
 [project.urls]
 Homepage = "https://github.com/digitalsleuth/peepdf-3"


### PR DESCRIPTION
This will allow peepdf-3 to be installed in AWS Lambda environments as it sets lxml to be optional, but it can still be installed with lxml using `python3 -m pip install peepdf-3[lxml]`