### PR TITLE
Fix embed

### DIFF
--- a/peepdf/PDFConsole.py
+++ b/peepdf/PDFConsole.py
@@ -752,7 +752,7 @@ class PDFConsole(cmd.Cmd):
             self.log_output("embed " + argv, message)
             return False
 
-        hexFileNameObject = PDFHexString(fileName.encode("hex"))
+        hexFileNameObject = PDFHexString(fileName.encode("utf-8").hex())
         md5Hash = hashlib.md5(fileContent).hexdigest()
         fileSize = len(fileContent)
         paramsDic = PDFDictionary(

--- a/peepdf/PDFConsole.py
+++ b/peepdf/PDFConsole.py
@@ -752,13 +752,13 @@ class PDFConsole(cmd.Cmd):
             self.log_output("embed " + argv, message)
             return False
 
-        hexFileNameObject = PDFHexString(fileName.encode("utf-8").hex())
+        hexFileNameObject = PDFHexString(fileName.encode().hex())
         md5Hash = hashlib.md5(fileContent).hexdigest()
         fileSize = len(fileContent)
         paramsDic = PDFDictionary(
             elements={
                 "/Size": PDFNum(str(fileSize)),
-                "/Checksum": PDFHexString(md5Hash),
+                "/Checksum": PDFHexString(md5Hash, IS_HASH=True),
             }
         )
         embeddedFileElements = {

--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -7033,7 +7033,7 @@ class PDFFile:
                     self.errors.remove(error)
 
     def save(
-        self, filename, pdfPath, version=None, malformedOptions=None, headerFile=None
+        self, filename, version=None, malformedOptions=None, headerFile=None
     ):
         if malformedOptions is None:
             malformedOptions = []
@@ -7179,7 +7179,7 @@ class PDFFile:
                 self.body[v].setObjects(indirectObjects)
                 offset = len(outputFileContent)
             if os.sep not in filename:
-                outputPath = f"{pdfPath}{os.sep}{filename}"
+                outputPath = os.path.realpath(filename)
             else:
                 outputPath = filename
             if isinstance(outputFileContent, str):

--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -747,7 +747,7 @@ class PDFHexString(PDFObject):
     Hexadecimal string object of a PDF document
     """
 
-    def __init__(self, hexData, IS_ID=False):
+    def __init__(self, hexData, IS_ID=False, IS_HASH=False):
         self.asciiValue = ""
         self.objType = "hexstring"
         self.errors = []
@@ -766,6 +766,7 @@ class PDFHexString(PDFObject):
         self.referencesInElements = {}
         self.references = []
         self.IS_ID = IS_ID
+        self.IS_HASH = IS_HASH
         ret = self.update()
         if ret[0] == -1:
             if isForceMode:
@@ -803,6 +804,8 @@ class PDFHexString(PDFObject):
                 self.encryptedValue = self.value
                 if self.IS_ID:
                     self.value = f"<{self.rawValue}>"
+                if self.IS_HASH:
+                    self.value = self.rawValue
             except:
                 errorMessage = "[!] Error in hexadecimal conversion"
                 self.addError(errorMessage)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "Pillow",
   "pythonaes",
   "lxml",
-  "prettytable>=3.9.0",
+  "prettytable>=3.12.0",
   "STPyV8",
 ]
 requires-python = ">=3.9"
@@ -29,7 +29,7 @@ maintainers = [
 ]
 description = "A Python 3 tool to explore, analyse, and disassemble PDF files"
 readme = "README.md"
-license = {file = "COPYING"}
+license-files = ["COPYING"]
 keywords = ["pdf", "peepdf", "forensics"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This will fix the encoding error from Python 2 days, and also fixes an issue with saving the current PDF. It also changes the pyproject.toml to be PEP 639 compliant, and bumps the required version of PrettyTable to 3.12.