### PR TITLE
prevent <info object> from changing object's value

### DIFF
--- a/peepdf/PDFCore.py
+++ b/peepdf/PDFCore.py
@@ -1521,12 +1521,13 @@ class PDFDictionary(PDFObject):
         return self.referencedJSObjects
 
     def getStats(self):
-        if isinstance(self.value, str):
-            self.value = self.value.encode()
+        value = self.value
+        if isinstance(value, str):
+            value = value.encode()
         stats = {
             "Object": self.objType,
-            "MD5": hashlib.md5(self.value).hexdigest(),
-            "SHA1": hashlib.sha1(self.value).hexdigest(),
+            "MD5": hashlib.md5(value).hexdigest(),
+            "SHA1": hashlib.sha1(value).hexdigest(),
             "References": str(
                 sorted(self.references, key=lambda x: int(refRegex.search(x).group()))
             ),


### PR DESCRIPTION
resolve the following TypeError

PPDF> references to <oid>
No references
PPDF> info <oid>
...
PPDF> references to <oid>

Traceback (most recent call last):
  File ".../py3.venv/lib64/python3.12/site-packages/peepdf/peepdf.py", line 598, in main
    console.cmdloop()
  File "/usr/lib64/python3.12/cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/cmd.py", line 217, in onecmd
    return func(arg)
           ^^^^^^^^^
  File ".../py3.venv/lib64/python3.12/site-packages/peepdf/PDFConsole.py", line 3631, in do_references
    references = self.pdfFile.getReferencesTo(thisId, version)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../py3.venv/lib64/python3.12/site-packages/peepdf/PDFCore.py", line 6547, in getReferencesTo
    re.findall(
  File "/usr/lib64/python3.12/re/__init__.py", line 217, in findall
    return _compile(pattern, flags).findall(string)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot use a string pattern on a bytes-like object