### PR TITLE
PDFFilters.py - Float Range Patch

### DIFF
--- a/peepdf/PDFFilters.py
+++ b/peepdf/PDFFilters.py
@@ -521,7 +521,7 @@ def post_prediction(decodedStream, predictor, columns, colors, bits):
     # TIFF - 2
     # http://www.gnupdf.org/PNG_and_TIFF_Predictors_Filter#TIFF
     if predictor == 2:
-        numRows = len(decodedStream) / bytesPerRow
+        numRows = int(len(decodedStream) / bytesPerRow)
         bitmask = 2**bits - 1
         outputBitsStream = ""
         for rowIndex in range(numRows):


### PR DESCRIPTION
Some cases had it calculated out as a float. Forcing int() to make it valid for range()

No verification of whether off-by-1 bugs might result from this