### PR TITLE
STPyV8 Import Patch

### DIFF
--- a/peepdf/JSAnalysis.py
+++ b/peepdf/JSAnalysis.py
@@ -51,6 +51,7 @@ try:
 
 except ModuleNotFoundError:
     JS_MODULE = False
+    STPyV8 = None
 
 ERROR_LOG = f"peepdf_jserrors-{dt.now().strftime(DTFMT)}.txt"
 currentDir = os.getcwd()

--- a/peepdf/PDFConsole.py
+++ b/peepdf/PDFConsole.py
@@ -50,7 +50,7 @@ try:
         DTFMT,
     )
     from peepdf.PDFCrypto import xor
-    from peepdf.JSAnalysis import isJavascript, analyseJS, unescape, JS_MODULE
+    from peepdf.JSAnalysis import isJavascript, analyseJS, unescape, JS_MODULE, STPyV8
     from peepdf.PDFCore import (
         PDFFile,
         PDFHexString,

--- a/peepdf/PDFConsole.py
+++ b/peepdf/PDFConsole.py
@@ -86,7 +86,7 @@ except ModuleNotFoundError:
         DTFMT,
     )
     from PDFCrypto import xor
-    from JSAnalysis import isJavascript, analyseJS, unescape, JS_MODULE
+    from JSAnalysis import isJavascript, analyseJS, unescape, JS_MODULE, STPyV8
     from PDFCore import (
         PDFFile,
         PDFHexString,

--- a/peepdf/peepdf.py
+++ b/peepdf/peepdf.py
@@ -38,14 +38,14 @@ try:
     from peepdf.PDFUtils import vtcheck, getPeepJSON, getPeepXML, getUpdate, DTFMT
     from peepdf.PDFVulns import vulnsDict
     from peepdf.PDFConsole import PDFConsole, EMU_MODULE
-    from peepdf.JSAnalysis import JS_MODULE, STPyV8
+    from peepdf.JSAnalysis import JS_MODULE
     from peepdf.PDFFilters import PIL_MODULE
 except ModuleNotFoundError:
     from PDFCore import PDFParser, VERSION
     from PDFUtils import vtcheck, getPeepJSON, getPeepXML, getUpdate, DTFMT
     from PDFVulns import vulnsDict
     from PDFConsole import PDFConsole, EMU_MODULE
-    from JSAnalysis import JS_MODULE, STPyV8
+    from JSAnalysis import JS_MODULE
     from PDFFilters import PIL_MODULE
 
 try:


### PR DESCRIPTION
Current import method of STPyV8 does not flow onwards: is not imported in certain/all cases
This _should_ enable it to be imported properly

For example, undefined variable error will occur in usage of:
```
peepdf -C 'js_eval object #' -fl FILE
```

Like my other pull requests, these haven't been tested for flow on effects, etc