### PR TITLE
fix clear command

### DIFF
--- a/peepdf/PDFConsole.py
+++ b/peepdf/PDFConsole.py
@@ -367,7 +367,7 @@ class PDFConsole(cmd.Cmd):
             f"{newLine}Shows the changelog of the document or version of the document {newLine}"
         )
 
-    def do_clear(self):
+    def do_clear(self, argv):
         clearScreen()
 
     def help_clear(self):


### PR DESCRIPTION
When running peepdf in interactive mode, the clear command doesn't work due to an extra argument being provided by the command loop. The following output is from the current `develop` branch:

```
PPDF> clear
[!] Error: Exception not handled using the interactive console - please report it to the author.

20250820-115702 | ERROR    | [!] Error: Exception not handled using the interactive console - please report it to the author.
20250820-115702 | ERROR    | PDFConsole.do_clear() takes 1 positional argument but 2 were given
```

This PR fixes this by adding an unused `argv` parameter, which is how the `exit` command is currently defined.